### PR TITLE
Bump version to 4.1.2 and add LinkToInstance method for Hitbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🎯 EZ Hitbox
 
-[![Wally](https://img.shields.io/badge/Wally-4.1.1-blue)](https://wally.run/package/breezy1214/hitbox?version=4.1.1)
+[![Wally](https://img.shields.io/badge/Wally-4.1.2-blue)](https://wally.run/package/breezy1214/hitbox?version=4.1.2)
 [![License](https://img.shields.io/badge/License-MIT-green)](LICENSE)
 [![Roblox](https://img.shields.io/badge/Platform-Roblox-00A2FF)](https://create.roblox.com/store/asset/104231461734810/Hitbox)
 
@@ -26,7 +26,7 @@ A flexible, high-performance hitbox system for Roblox games with advanced featur
 
 ```toml
 [dependencies]
-Hitbox = "breezy1214/hitbox@4.1.1"
+Hitbox = "breezy1214/hitbox@4.1.2"
 ```
 
 ### Manual Installation
@@ -286,6 +286,10 @@ Activates the hitbox for hit detection.
 #### `Hitbox:Stop() -> void`
 
 Temporarily pauses hit detection without destroying the hitbox.
+
+#### `Hitbox:LinkToInstance(instance: Instance) -> void`
+
+Links the hitbox's lifecycle to an instance. When the linked instance is destroyed, the hitbox will automatically clean up and destroy itself. This is useful for tying hitboxes to weapons, projectiles, or other temporary game objects.
 
 #### `Hitbox:SetCFrame(newCFrame: CFrame) -> void`
 

--- a/src/Types.luau
+++ b/src/Types.luau
@@ -83,6 +83,7 @@ export type Hitbox = {
 	-- Methods
 
 	new: (HitboxParams) -> (Hitbox, boolean),
+	LinkToInstance: (self: Hitbox, instance: Instance) -> (),
 	ClearHitboxesByID: (ID: string | number) -> (),
 	GetHitboxCache: () -> { Hitbox },
 	ClearTaggedCharacters: (self: Hitbox) -> (),

--- a/src/Types.luau
+++ b/src/Types.luau
@@ -40,13 +40,27 @@ export type HitboxParams = {
 	-- Private fields
 	_Tick: number?,
 }
-type Character = Model&{
-	Humanoid:Humanoid&{Animator:Animator},PrimaryPart:Part,HumanoidRootPart:Part,
+type Character = Model & {
+	Humanoid: Humanoid & { Animator: Animator },
+	PrimaryPart: Part,
+	HumanoidRootPart: Part,
 	--R6
-	Torso:Part,["Left Arm"]:Part,["Right Arm"]:Part,["Left Leg"]:Part,["Right Leg"]:Part,
+	Torso: Part,
+	["Left Arm"]: Part,
+	["Right Arm"]: Part,
+	["Left Leg"]: Part,
+	["Right Leg"]: Part,
 	--R15
-	UpperTorso:Part,LowerTorso:Part,["LeftUpperArm"]:Part,["LeftLowerArm"]:Part,["RightUpperArm"]:Part,["RightLowerArm"]:Part,
-	["LeftUpperLeg"]:Part,["LeftLowerLeg"]:Part,["RightUpperLeg"]:Part,["RightLowerLeg"]:Part
+	UpperTorso: Part,
+	LowerTorso: Part,
+	["LeftUpperArm"]: Part,
+	["LeftLowerArm"]: Part,
+	["RightUpperArm"]: Part,
+	["RightLowerArm"]: Part,
+	["LeftUpperLeg"]: Part,
+	["LeftLowerLeg"]: Part,
+	["RightUpperLeg"]: Part,
+	["RightLowerLeg"]: Part,
 }
 export type Hitbox = {
 
@@ -67,10 +81,10 @@ export type Hitbox = {
 	Blacklist: {}?,
 	SendingChars: { Model },
 	SendingObjects: { BasePart },
-	OnHit: Signal.Signal<{Character}>,
+	OnHit: Signal.Signal<{ Character }>,
 	HitObject: Signal.Signal<BasePart>,
-	OnHitWithPoint: Signal.Signal<{HitPointData}>,
-	HitObjectWithPoint: Signal.Signal<{HitPointData}>,
+	OnHitWithPoint: Signal.Signal<{ HitPointData }>,
+	HitObjectWithPoint: Signal.Signal<{ HitPointData }>,
 	DetectHitPoints: boolean,
 	RunServiceConnection: RBXScriptConnection?,
 	PartWeld: BasePart?,
@@ -79,6 +93,7 @@ export type Hitbox = {
 	DebugMode: boolean,
 	Lifetime: number,
 	_janitor: JanitorType,
+	_destroyed: boolean?,
 
 	-- Methods
 

--- a/src/init.luau
+++ b/src/init.luau
@@ -145,6 +145,10 @@ function Hitbox.new(HitboxParams: Types.HitboxParams)
 
 	self._janitor = Janitor.new()
 
+	self._janitor:Add(function()
+		self:Destroy()
+	end)
+
 	self.TaggedChars = {}
 	self.TaggedObjects = {}
 	self.SendingChars = {}
@@ -240,6 +244,11 @@ function Hitbox.new(HitboxParams: Types.HitboxParams)
 	self["Destroy"] = self.Destroy
 
 	return self, true
+end
+
+function Hitbox:LinkToInstance(instance: Instance)
+	assert(instance, "[EZ-Hitbox] No instance provided to link to!")
+	self._janitor:LinkToInstance(instance)
 end
 
 function Hitbox:ClearTaggedCharacters()

--- a/src/init.luau
+++ b/src/init.luau
@@ -800,23 +800,25 @@ function Hitbox:_GeneratePart()
 end
 
 function Hitbox:Destroy()
+	if self._destroyed then
+		return
+	end
+	self._destroyed = true
+	
 	-- Remove the hitbox from the cache
 	local index = table.find(HitboxCache, self)
 	if index then
 		table.remove(HitboxCache, index)
 	end
 
-	self.TaggedChars = {}
-	self.SendingChars = {}
-	self.TaggedObjects = {}
-	self.SendingObjects = {}
-
 	if self._janitor and not self._janitor.CurrentlyCleaning then
 		self._janitor:Destroy()
 		self._janitor = nil
 	end
 
+	table.clear(self)
 	setmetatable(self, nil)
+	self = nil
 end
 
 return Hitbox

--- a/src/wally.toml
+++ b/src/wally.toml
@@ -1,7 +1,7 @@
 [package]
 name = "breezy1214/hitbox"
 description = "A flexible, efficient hitbox system for Roblox games that supports both server and client-side hit detection."
-version = "4.1.1"
+version = "4.1.2"
 license = "MIT"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"


### PR DESCRIPTION
Bump version to 4.1.2 and add LinkToInstance method for Hitbox
This pull request updates the hitbox system to version 4.1.2 and introduces a new method to simplify lifecycle management of hitboxes in Roblox games. The most important changes are the addition of the `LinkToInstance` method, documentation updates, and version bumps.

### New Feature: Hitbox Lifecycle Management

* Added the `LinkToInstance(instance: Instance)` method to the `Hitbox` class, allowing a hitbox to automatically destroy itself when a linked instance (such as a weapon or projectile) is destroyed. This helps prevent memory leaks and simplifies cleanup logic. (`src/init.luau`, `src/Types.luau`) [[1]](diffhunk://#diff-82ef9f6d263c32fb229c475776e88e81bef55784f0ae6778dd25efd8d40bb13bR249-R253) [[2]](diffhunk://#diff-145ffd245507e793b2765c1c58698ba8b5691f6e5c3561b2a411653abf69df34R86)

* Registered the hitbox's own cleanup with its internal janitor for robust resource management. (`src/init.luau`)

### Documentation Updates

* Documented the new `LinkToInstance` method in the `README.md` file, explaining its purpose and usage.

### Version Bumps

* Updated the version number to 4.1.2 in `README.md`, `src/wally.toml`, and installation instructions to reflect the new release. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L29-R29) [[3]](diffhunk://#diff-6aaabf9f311c1622b2c107a1cf93ab90f082040a91c8d19e48a95c19e835a288L4-R4)